### PR TITLE
Introduce indexing for 1d arrays (using an nd approach)

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -601,8 +601,6 @@ class _spbase:
         if issparse(other):
             if self.shape[-1] != other.shape[0]:
                 raise ValueError('dimension mismatch')
-            if other.ndim == 1:
-                raise ValueError('Cannot yet multiply a 1d sparse array')
             return self._matmul_sparse(other)
 
         # If it's a list or whatever, treat it like an array

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -865,7 +865,7 @@ class _spbase:
         # convert to COOrdinate format
         A = self.tocoo()
         nz_mask = A.data != 0
-        return (A.row[nz_mask], A.col[nz_mask])
+        return tuple(idx[nz_mask] for idx in A.coords)
 
     def _getcol(self, j):
         """Returns a copy of column j of the array, as an (m x 1) sparse

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -7,7 +7,7 @@ import operator
 import numpy as np
 from scipy._lib._util import _prune_array
 
-from ._base import _spbase, issparse, SparseEfficiencyWarning
+from ._base import _spbase, issparse, sparray, SparseEfficiencyWarning
 from ._data import _data_matrix, _minmax_mixin
 from . import _sparsetools
 from ._sparsetools import (get_csr_submatrix, csr_sample_offsets, csr_todense,
@@ -26,34 +26,35 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         _data_matrix.__init__(self)
+        is_array = isinstance(self, sparray)
 
         if issparse(arg1):
+            self._shape = arg1.shape
             if arg1.format == self.format and copy:
                 arg1 = arg1.copy()
             else:
                 arg1 = arg1.asformat(self.format)
-            self._set_self(arg1)
+            self._set_self(arg1, allow_1d=is_array)
 
         elif isinstance(arg1, tuple):
-            if isshape(arg1):
+            if isshape(arg1, allow_1d=is_array):
                 # It's a tuple of matrix dimensions (M, N)
                 # create empty matrix
-                self._shape = check_shape(arg1)
-                M, N = self.shape
+                self._shape = check_shape(arg1, allow_1d=is_array)
+                M, N = self._swap(self._shape_as_2d)
                 # Select index dtype large enough to pass array and
                 # scalar parameters to sparsetools
-                idx_dtype = self._get_index_dtype(maxval=max(M, N))
+                idx_dtype = self._get_index_dtype(maxval=max(self.shape))
                 self.data = np.zeros(0, getdtype(dtype, default=float))
                 self.indices = np.zeros(0, idx_dtype)
-                self.indptr = np.zeros(self._swap((M, N))[0] + 1,
-                                       dtype=idx_dtype)
+                self.indptr = np.zeros(M + 1, dtype=idx_dtype)
             else:
                 if len(arg1) == 2:
                     # (data, ij) format
                     other = self.__class__(
                         self._coo_container(arg1, shape=shape, dtype=dtype)
                     )
-                    self._set_self(other)
+                    self._set_self(other, allow_1d=is_array)
                 elif len(arg1) == 3:
                     # (data, indices, indptr) format
                     (data, indices, indptr) = arg1
@@ -61,45 +62,42 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                     # Select index dtype large enough to pass array and
                     # scalar parameters to sparsetools
                     maxval = None
-                    if shape is not None:
+                    if shape is not None and 0 not in shape:
                         maxval = max(shape)
                     idx_dtype = self._get_index_dtype((indices, indptr),
                                                 maxval=maxval,
                                                 check_contents=True)
 
-                    self.indices = np.array(indices, copy=copy,
-                                            dtype=idx_dtype)
+                    self.indices = np.array(indices, copy=copy, dtype=idx_dtype)
                     self.indptr = np.array(indptr, copy=copy, dtype=idx_dtype)
                     self.data = np.array(data, copy=copy, dtype=dtype)
                 else:
-                    raise ValueError(f"unrecognized {self.format}_matrix "
-                                     "constructor usage")
+                    raise ValueError(f"unrecognized {self.format} "
+                                     f"constructor input: {arg1}")
 
         else:
             # must be dense
             try:
                 arg1 = np.asarray(arg1)
             except Exception as e:
-                msg = f"unrecognized {self.format}_matrix constructor usage"
-                raise ValueError(msg) from e
-            self._set_self(self.__class__(
-                self._coo_container(arg1, dtype=dtype)
-            ))
+                raise ValueError(f"unrecognized {self.format} constructor usage") from e
+            coo = self._coo_container(arg1, dtype=dtype)
+            self._set_self(self.__class__(coo), allow_1d=is_array)
 
         # Read matrix dimensions given, if any
         if shape is not None:
-            self._shape = check_shape(shape)
-        else:
-            if self.shape is None:
-                # shape not already set, try to infer dimensions
-                try:
-                    major_dim = len(self.indptr) - 1
-                    minor_dim = self.indices.max() + 1
-                except Exception as e:
-                    raise ValueError('unable to infer matrix dimensions') from e
-                else:
-                    self._shape = check_shape(self._swap((major_dim,
-                                                          minor_dim)))
+            self._shape = check_shape(shape, allow_1d=is_array)
+        elif self.shape is None:
+            # shape not already set, try to infer dimensions
+            try:
+                major_dim = len(self.indptr) - 1
+                minor_dim = self.indices.max() + 1
+            except Exception as e:
+                raise ValueError('unable to infer matrix dimensions') from e
+            else:
+                new_shape = (major_dim, minor_dim)
+                self._shape = check_shape(self._swap(new_shape),
+                                          allow_1d=is_array)
 
         if dtype is not None:
             self.data = self.data.astype(dtype, copy=False)
@@ -109,6 +107,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     def _getnnz(self, axis=None):
         if axis is None:
             return int(self.indptr[-1])
+        elif self.ndim == 1:
+            if axis in (0, -1):
+                return int(self.indptr[-1])
+            raise ValueError('axis out of bounds')
         else:
             if axis < 0:
                 axis += 2
@@ -123,16 +125,15 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
     _getnnz.__doc__ = _spbase._getnnz.__doc__
 
-    def _set_self(self, other, copy=False):
+    def _set_self(self, other, copy=False, allow_1d=False):
         """take the member variables of other and assign them to self"""
-
         if copy:
             other = other.copy()
 
         self.data = other.data
         self.indices = other.indices
         self.indptr = other.indptr
-        self._shape = check_shape(other.shape)
+        self._shape = check_shape(other.shape, allow_1d=allow_1d)
 
     def check_format(self, full_check=True):
         """Check whether the array/matrix respects the CSR or CSC format.
@@ -146,10 +147,6 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             If `False`, run basic checks on attributes. O(1) operations.
             Default is `True`.
         """
-        # use _swap to determine proper bounds
-        major_name, minor_name = self._swap(('row', 'column'))
-        major_dim, minor_dim = self._swap(self.shape)
-
         # index arrays should have integer data types
         if self.indptr.dtype.kind != 'i':
             warn(f"indptr array has non-integer dtype ({self.indptr.dtype.name})",
@@ -163,10 +160,12 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             if x != 1:
                 raise ValueError('data, indices, and indptr should be 1-D')
 
-        # check index pointer
-        if (len(self.indptr) != major_dim + 1):
-            raise ValueError("index pointer size ({}) should be ({})"
-                             "".format(len(self.indptr), major_dim + 1))
+        # check index pointer. Use _swap to determine proper bounds
+        M, N = self._swap(self._shape_as_2d)
+
+        if (len(self.indptr) != M + 1):
+            msg = f"index pointer size ({len(self.indptr)}) should be ({M + 1})"
+            raise ValueError(msg)
         if (self.indptr[0] != 0):
             raise ValueError("index pointer should start with 0")
 
@@ -182,10 +181,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         if full_check:
             # check format validity (more expensive)
             if self.nnz > 0:
-                if self.indices.max() >= minor_dim:
-                    raise ValueError(f"{minor_name} index values must be < {minor_dim}")
+                if self.indices.max() >= N:
+                    raise ValueError(f"index values must be < {N}")
                 if self.indices.min() < 0:
-                    raise ValueError(f"{minor_name} index values must be >= 0")
+                    raise ValueError("index values must be >= 0")
                 if np.diff(self.indptr).min() < 0:
                     raise ValueError("index pointer values must form a "
                                      "non-decreasing sequence")
@@ -353,8 +352,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         dtype = upcast_char(self.dtype.char, other.dtype.char)
         order = self._swap('CF')[0]
         result = np.array(other, dtype=dtype, order=order, copy=True)
-        M, N = self._swap(self.shape)
         y = result if result.flags.c_contiguous else result.T
+        M, N = self._swap(self._shape_as_2d)
         csr_todense(M, N, self.indptr, self.indices, self.data, y)
         return self._container(result, copy=False)
 
@@ -365,9 +364,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         return self._binopt(other, '_minus_')
 
     def multiply(self, other):
-        """Point-wise multiplication by another array/matrix, vector, or
-        scalar.
-        """
+        """Point-wise multiplication by array/matrix, vector, or scalar."""
         # Scalar multiplication.
         if isscalarlike(other):
             return self._mul_scalar(other)
@@ -376,105 +373,127 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             if self.shape == other.shape:
                 other = self.__class__(other)
                 return self._binopt(other, '_elmul_')
-            if other.ndim == 1:
-                raise TypeError("broadcast from a 1d array not yet supported")
             # Single element.
-            elif other.shape == (1, 1):
-                return self._mul_scalar(other.toarray()[0, 0])
-            elif self.shape == (1, 1):
-                return other._mul_scalar(self.toarray()[0, 0])
+            if other.shape == (1, 1):
+                result = self._mul_scalar(other.toarray()[0, 0])
+                if self.ndim == 1:
+                    return result.reshape((1, self.shape[0]))
+                return result
+            if other.shape == (1,):
+                return self._mul_scalar(other.toarray()[0])
+            if self.shape == (1, 1):
+                result = other._mul_scalar(self.toarray()[0, 0])
+                if self.ndim == 1:
+                    return result.reshape((1, other.shape[0]))
+                return result
+            if self.shape == (1,):
+                return other._mul_scalar(self.toarray()[0])
+
+            # broadcast. treat 1d like a row
+            sM, sN = self._shape_as_2d
+            oM, oN = other._shape_as_2d
             # A row times a column.
-            elif self.shape[1] == 1 and other.shape[0] == 1:
-                return self._matmul_sparse(other.tocsc())
-            elif self.shape[0] == 1 and other.shape[1] == 1:
-                return other._matmul_sparse(self.tocsc())
-            # Row vector times matrix. other is a row.
-            elif other.shape[0] == 1 and self.shape[1] == other.shape[1]:
-                other = self._dia_container(
-                    (other.toarray().ravel(), [0]),
-                    shape=(other.shape[1], other.shape[1])
-                )
-                return self._matmul_sparse(other)
+            if sM == 1 and oN == 1:
+                return other._matmul_sparse(self.reshape(sM, sN).tocsc())
+            if sN == 1 and oM == 1:
+                return self._matmul_sparse(other.reshape(oM, oN).tocsc())
+
+            # Other is a row.
+            if oM == 1 and sN == oN:
+                # build diagonal csc_array/csr_array => self._csr_container
+                data = other.toarray().ravel()
+                indptr = np.arange(oN + 1)
+                indices = indptr[:-1]
+                new_other = self._csr_container((data, indices, indptr))
+                result = self._matmul_sparse(new_other)
+                return result if self.ndim == 2 else result.reshape((1, oN))
             # self is a row.
-            elif self.shape[0] == 1 and self.shape[1] == other.shape[1]:
-                copy = self._dia_container(
-                    (self.toarray().ravel(), [0]),
-                    shape=(self.shape[1], self.shape[1])
-                )
+            if sM == 1 and sN == oN:
+                data = self.toarray().ravel()
+                indptr = np.arange(oN + 1)
+                indices = indptr[:-1]
+                copy = self._csr_container((data, indices, indptr))
                 return other._matmul_sparse(copy)
-            # Column vector times matrix. other is a column.
-            elif other.shape[1] == 1 and self.shape[0] == other.shape[0]:
-                other = self._dia_container(
-                    (other.toarray().ravel(), [0]),
-                    shape=(other.shape[0], other.shape[0])
-                )
-                return other._matmul_sparse(self)
+
+            # Other is a column.
+            if oN == 1 and sM == oM:
+                data = other.toarray().ravel()
+                indptr = np.arange(oM + 1)
+                indices = indptr[:-1]
+                new_other = self._csr_container((data, indices, indptr))
+                return new_other._matmul_sparse(self)
             # self is a column.
-            elif self.shape[1] == 1 and self.shape[0] == other.shape[0]:
-                copy = self._dia_container(
-                    (self.toarray().ravel(), [0]),
-                    shape=(self.shape[0], self.shape[0])
-                )
-                return copy._matmul_sparse(other)
-            else:
-                raise ValueError("inconsistent shapes")
+            if sN == 1 and sM == oM:
+                data = self.toarray().ravel()
+                indptr = np.arange(oM + 1)
+                indices = indptr[:-1]
+                new_self = self._csr_container((data, indices, indptr))
+                return new_self._matmul_sparse(other)
+            raise ValueError("inconsistent shapes")
 
         # Assume other is a dense matrix/array, which produces a single-item
         # object array if other isn't convertible to ndarray.
-        other = np.atleast_2d(other)
+        other = np.asanyarray(other)
 
-        if other.ndim != 2:
+        if other.ndim > 2:
             return np.multiply(self.toarray(), other)
         # Single element / wrapped object.
         if other.size == 1:
-            if other.dtype == np.object_:
-                # 'other' not convertible to ndarray.
-                return NotImplemented
-            return self._mul_scalar(other.flat[0])
+            bshape = np.broadcast_shapes(self.shape, other.shape)
+            return self._mul_scalar(other.flat[0]).reshape(bshape)
         # Fast case for trivial sparse matrix.
-        elif self.shape == (1, 1):
-            return np.multiply(self.toarray()[0, 0], other)
+        if self.shape == (1, 1):
+            bshape = np.broadcast_shapes(self.shape, other.shape)
+            return np.multiply(self.toarray()[0, 0], other).reshape(bshape)
+        if self.shape == (1,):
+            bshape = np.broadcast_shapes(self.shape, other.shape)
+            return np.multiply(self.toarray()[0], other).reshape(bshape)
 
         ret = self.tocoo()
         # Matching shapes.
         if self.shape == other.shape:
-            data = np.multiply(ret.data, other[ret.row, ret.col])
+            data = np.multiply(ret.data, other[ret.coords])
+            ret.data = data.view(np.ndarray).ravel()
+            return ret
+
+        # convert other to 2d
+        other2d = np.atleast_2d(other)
         # Sparse row vector times...
-        elif self.shape[0] == 1:
-            if other.shape[1] == 1:  # Dense column vector.
-                data = np.multiply(ret.data, other)
-            elif other.shape[1] == self.shape[1]:  # Dense matrix.
-                data = np.multiply(ret.data, other[:, ret.col])
+        if self.shape[0] == 1 or self.ndim == 1:
+            if other2d.shape[1] == 1:  # Dense column vector.
+                data = np.multiply(ret.data, other2d)
+            elif other2d.shape[1] == self.shape[-1]:  # Dense 2d matrix.
+                data = np.multiply(ret.data, other2d[:, ret.col])
             else:
                 raise ValueError("inconsistent shapes")
-            row = np.repeat(np.arange(other.shape[0]), len(ret.row))
-            col = np.tile(ret.col, other.shape[0])
+            row = np.repeat(np.arange(other2d.shape[0]), ret.nnz)
+            col = np.tile(ret.col, other2d.shape[0])
             return self._coo_container(
                 (data.view(np.ndarray).ravel(), (row, col)),
-                shape=(other.shape[0], self.shape[1]),
+                shape=(other2d.shape[0], self.shape[-1]),
                 copy=False
             )
         # Sparse column vector times...
-        elif self.shape[1] == 1:
-            if other.shape[0] == 1:  # Dense row vector.
-                data = np.multiply(ret.data[:, None], other)
-            elif other.shape[0] == self.shape[0]:  # Dense matrix.
-                data = np.multiply(ret.data[:, None], other[ret.row])
+        if self.shape[1] == 1:
+            if other2d.shape[0] == 1:  # Dense row vector.
+                data = np.multiply(ret.data[:, None], other2d)
+            elif other2d.shape[0] == self.shape[0]:  # Dense 2d array.
+                data = np.multiply(ret.data[:, None], other2d[ret.row])
             else:
                 raise ValueError("inconsistent shapes")
-            row = np.repeat(ret.row, other.shape[1])
-            col = np.tile(np.arange(other.shape[1]), len(ret.col))
+            row = np.repeat(ret.row, other2d.shape[1])
+            col = np.tile(np.arange(other2d.shape[1]), len(ret.col))
             return self._coo_container(
                 (data.view(np.ndarray).ravel(), (row, col)),
-                shape=(self.shape[0], other.shape[1]),
+                shape=(self.shape[0], other2d.shape[1]),
                 copy=False
             )
         # Sparse matrix times dense row vector.
-        elif other.shape[0] == 1 and self.shape[1] == other.shape[1]:
-            data = np.multiply(ret.data, other[:, ret.col].ravel())
+        if other2d.shape[0] == 1 and self.shape[1] == other2d.shape[1]:
+            data = np.multiply(ret.data, other2d[:, ret.col].ravel())
         # Sparse matrix times dense column vector.
-        elif other.shape[1] == 1 and self.shape[0] == other.shape[0]:
-            data = np.multiply(ret.data, other[ret.row].ravel())
+        elif other2d.shape[1] == 1 and self.shape[0] == other2d.shape[0]:
+            data = np.multiply(ret.data, other2d[ret.row].ravel())
         else:
             raise ValueError("inconsistent shapes")
         ret.data = data.view(np.ndarray).ravel()
@@ -485,21 +504,20 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     ###########################
 
     def _matmul_vector(self, other):
-        M, N = self.shape
+        M, N = self._shape_as_2d
 
         # output array
-        result = np.zeros(M, dtype=upcast_char(self.dtype.char,
-                                               other.dtype.char))
+        result = np.zeros(M, dtype=upcast_char(self.dtype.char, other.dtype.char))
 
         # csr_matvec or csc_matvec
         fn = getattr(_sparsetools, self.format + '_matvec')
         fn(M, N, self.indptr, self.indices, self.data, other, result)
 
-        return result
+        return result[0] if self.ndim == 1 else result
 
     def _matmul_multivector(self, other):
-        M, N = self.shape
-        n_vecs = other.shape[1]  # number of column vectors
+        M, N = self._shape_as_2d
+        n_vecs = other.shape[-1]  # number of column vectors
 
         result = np.zeros((M, n_vecs),
                           dtype=upcast_char(self.dtype.char, other.dtype.char))
@@ -509,11 +527,25 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         fn(M, N, n_vecs, self.indptr, self.indices, self.data,
            other.ravel(), result.ravel())
 
+        if self.ndim == 1:
+            return result.reshape((n_vecs,))
         return result
 
     def _matmul_sparse(self, other):
-        M, K1 = self.shape
-        K2, N = other.shape
+        M, K1 = self._shape_as_2d
+        # if other is 1d, treat as a **column**
+        K2, N = other._shape_as_2d
+
+        # find new_shape
+        if self.ndim == 2:
+            if other.ndim == 2:
+                new_shape = (M, N)
+            else:
+                new_shape = (M,)
+        elif other.ndim == 2:
+            new_shape = (N,)
+        else:
+            new_shape = (1,)
 
         major_axis = self._swap((M, N))[0]
         other = self.__class__(other)  # convert to this format
@@ -527,6 +559,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                  np.asarray(self.indices, dtype=idx_dtype),
                  np.asarray(other.indptr, dtype=idx_dtype),
                  np.asarray(other.indices, dtype=idx_dtype))
+        if nnz == 0:
+            return self.__class__(new_shape, dtype=upcast(self.dtype, other.dtype))
 
         idx_dtype = self._get_index_dtype((self.indptr, self.indices,
                                      other.indptr, other.indices),
@@ -545,7 +579,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
            other.data,
            indptr, indices, data)
 
-        return self.__class__((data, indices, indptr), shape=(M, N))
+        return self.__class__((data, indices, indptr), shape=new_shape)
 
     def diagonal(self, k=0):
         rows, cols = self.shape
@@ -609,8 +643,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         """
         # The _spbase base class already does axis=0 and axis=1 efficiently
         # so we only do the case axis=None here
-        if (not hasattr(self, 'blocksize') and
-                axis in self._swap(((1, -1), (0, 2)))[0]):
+        if (self.ndim == 2 and not hasattr(self, 'blocksize') and
+                axis in self._swap(((1, -1), (0, -2)))[0]):
             # faster than multiplication for large minor axis in CSC/CSR
             res_dtype = get_sum_dtype(self.dtype)
             ret = np.zeros(len(self.indptr) - 1, dtype=res_dtype)
@@ -625,9 +659,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 raise ValueError('dimensions do not match')
 
             return ret.sum(axis=(), dtype=dtype, out=out)
-        # _spbase will handle the remaining situations when axis
-        # is in {None, -1, 0, 1}
         else:
+            # _spbase handles the situations when axis is in {None, -1, 0, 1}
             return _spbase.sum(self, axis=axis, dtype=dtype, out=out)
 
     sum.__doc__ = _spbase.sum.__doc__
@@ -657,6 +690,42 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     #######################
     # Getting and Setting #
     #######################
+
+    def _get_int(self, idx):
+        if 0 <= idx <= self.shape[0]:
+            spot = np.flatnonzero(self.indices == idx)
+            if spot.size:
+                return self.data[spot[0]]
+            return self.data.dtype.type(0)
+        raise IndexError(f'index ({idx}) out of range')
+
+#    def _get_slice(self, idx):
+#        if idx == slice(None):
+#            return self.copy()
+#        if idx.step in (1, None):
+#            major, minor = self._swap((0, idx))
+#            ret = self._get_submatrix(major, minor, copy=True)
+#            return ret.reshape(ret.shape[-1])
+#
+#        _slice = self._swap((self._minor_slice, self._major_slice))[0]
+#        return _slice(idx)
+#
+#    def _get_array(self, idx):
+#        idx = np.asarray(idx)
+#        idx_dtype = self.indices.dtype
+#        M, N = self._swap((1, self.shape[0]))
+#        row = np.zeros_like(idx, dtype=idx_dtype)
+#        major, minor = self._swap((row, idx))
+#        major = np.asarray(major, dtype=idx_dtype)
+#        minor = np.asarray(minor, dtype=idx_dtype)
+#        if minor.size == 0:
+#            return self.__class__([], dtype=self.dtype)
+#        new_shape = minor.shape if minor.shape[0] > 1 else (minor.shape[-1],)
+#
+#        val = np.empty(major.size, dtype=self.dtype)
+#        csr_sample_values(M, N, self.indptr, self.indices, self.data,
+#                          major.size, major.ravel(), minor.ravel(), val)
+#        return self.__class__(val.reshape(new_shape))
 
     def _get_intXint(self, row, col):
         M, N = self._swap(self.shape)
@@ -698,15 +767,15 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         idx_dtype = self.indices.dtype
         indices = np.asarray(idx, dtype=idx_dtype).ravel()
 
-        _, N = self._swap(self.shape)
+        N = self._swap(self._shape_as_2d)[1]
         M = len(indices)
-        new_shape = self._swap((M, N))
+        new_shape = self._swap((M, N)) if self.ndim == 2 else (M,)
         if M == 0:
             return self.__class__(new_shape, dtype=self.dtype)
 
         row_nnz = self.indptr[indices + 1] - self.indptr[indices]
         idx_dtype = self.indices.dtype
-        res_indptr = np.zeros(M+1, dtype=idx_dtype)
+        res_indptr = np.zeros(M + 1, dtype=idx_dtype)
         np.cumsum(row_nnz, out=res_indptr[1:])
 
         nnz = res_indptr[-1]
@@ -724,10 +793,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         if idx == slice(None):
             return self.copy() if copy else self
 
-        M, N = self._swap(self.shape)
+        M, N = self._swap(self._shape_as_2d)
         start, stop, step = idx.indices(M)
         M = len(range(start, stop, step))
-        new_shape = self._swap((M, N))
+        new_shape = self._swap((M, N)) if self.ndim == 2 else (M,)
         if M == 0:
             return self.__class__(new_shape, dtype=self.dtype)
 
@@ -764,9 +833,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         idx_dtype = self.indices.dtype
         idx = np.asarray(idx, dtype=idx_dtype).ravel()
 
-        M, N = self._swap(self.shape)
+        M, N = self._swap(self._shape_as_2d)
         k = len(idx)
-        new_shape = self._swap((M, k))
+        new_shape = self._swap((M, k)) if self.ndim == 2 else (k,)
         if k == 0:
             return self.__class__(new_shape, dtype=self.dtype)
 
@@ -792,7 +861,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         if idx == slice(None):
             return self.copy() if copy else self
 
-        M, N = self._swap(self.shape)
+        M, N = self._swap(self._shape_as_2d)
         start, stop, step = idx.indices(N)
         N = len(range(start, stop, step))
         if N == 0:
@@ -807,7 +876,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         major, minor: None, int, or slice with step 1
         """
-        M, N = self._swap(self.shape)
+        M, N = self._swap(self._shape_as_2d)
         i0, i1 = _process_slice(major, M)
         j0, j1 = _process_slice(minor, N)
 
@@ -818,8 +887,21 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             M, N, self.indptr, self.indices, self.data, i0, i1, j0, j1)
 
         shape = self._swap((i1 - i0, j1 - j0))
+        if self.ndim == 1:
+            shape = (shape[1],)
         return self.__class__((data, indices, indptr), shape=shape,
                               dtype=self.dtype, copy=False)
+
+    def _set_int(self, idx, x):
+        major, minor = self._swap((0, idx))
+        self._set_many(major, minor, x)
+
+    def _set_array(self, idx, x):
+        major, minor = self._swap((np.zeros_like(idx), idx))
+        broadcast = x.shape[-1] == 1 and minor.shape[-1] != 1
+        if broadcast:
+            x = np.repeat(x.data, idx.shape[-1])
+        self._set_many(major, minor, x)
 
     def _set_intXint(self, row, col, x):
         i, j = self._swap((row, col))
@@ -857,6 +939,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     def _setdiag(self, values, k):
         if 0 in self.shape:
             return
+        if self.ndim == 1:
+            raise NotImplementedError('diagonals cant be set in 1d arrays')
 
         M, N = self.shape
         broadcast = (values.ndim == 0)
@@ -885,7 +969,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         self[i, j] = values
 
     def _prepare_indices(self, i, j):
-        M, N = self._swap(self.shape)
+        M, N = self._swap(self._shape_as_2d)
 
         def check_bounds(indices, bound):
             idx = indices.max()
@@ -1039,6 +1123,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     ######################
 
     def tocoo(self, copy=True):
+        if self.ndim == 1:
+            csr = self.tocsr()
+            return self._coo_container((csr.data, (csr.indices,)), csr.shape, copy=copy)
         major_dim, minor_dim = self._swap(self.shape)
         minor_indices = self.indices
         major_indices = np.empty(len(minor_indices), dtype=self.indices.dtype)
@@ -1064,7 +1151,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         else:
             x = self.tocsc()
             y = out.T
-        M, N = x._swap(x.shape)
+        M, N = x._swap(x._shape_as_2d)
         csr_todense(M, N, x.indptr, x.indices, x.data, y)
         return out
 
@@ -1079,9 +1166,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         This is an *in place* operation.
         """
-        M, N = self._swap(self.shape)
-        _sparsetools.csr_eliminate_zeros(M, N, self.indptr, self.indices,
-                                         self.data)
+        M, N = self._swap(self._shape_as_2d)
+        _sparsetools.csr_eliminate_zeros(M, N, self.indptr, self.indices, self.data)
         self.prune()  # nnz may have changed
 
     @property
@@ -1122,9 +1208,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             return
         self.sort_indices()
 
-        M, N = self._swap(self.shape)
-        _sparsetools.csr_sum_duplicates(M, N, self.indptr, self.indices,
-                                        self.data)
+        M, N = self._swap(self._shape_as_2d)
+        _sparsetools.csr_sum_duplicates(M, N, self.indptr, self.indices, self.data)
 
         self.prune()  # nnz may have changed
         self.has_canonical_format = True
@@ -1173,7 +1258,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     def prune(self):
         """Remove empty space after all non-zero elements.
         """
-        major_dim = self._swap(self.shape)[0]
+        major_dim = self._swap(self._shape_as_2d)[0]
 
         if len(self.indptr) != major_dim + 1:
             raise ValueError('index pointer has invalid length')
@@ -1186,7 +1271,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         self.data = _prune_array(self.data[:self.nnz])
 
     def resize(self, *shape):
-        shape = check_shape(shape)
+        shape = check_shape(shape, allow_1d=isinstance(self, sparray))
+
         if hasattr(self, 'blocksize'):
             bm, bn = self.blocksize
             new_M, rm = divmod(shape[0], bm)
@@ -1196,8 +1282,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                                  "Got {}".format(self.blocksize, shape))
             M, N = self.shape[0] // bm, self.shape[1] // bn
         else:
-            new_M, new_N = self._swap(shape)
-            M, N = self._swap(self.shape)
+            new_M, new_N = self._swap(shape if len(shape)>1 else (1, shape[0]))
+            M, N = self._swap(self._shape_as_2d)
 
         if new_M < M:
             self.indices = self.indices[:self.indptr[new_M]]
@@ -1260,7 +1346,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         else:
             data = np.empty(maxnnz, dtype=upcast(self.dtype, other.dtype))
 
-        fn(self.shape[0], self.shape[1],
+        M, N = self._shape_as_2d
+        fn(M, N,
            np.asarray(self.indptr, dtype=idx_dtype),
            np.asarray(self.indices, dtype=idx_dtype),
            self.data,
@@ -1290,16 +1377,17 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             # inside it is either zero or defined by eldiv.
             out = np.empty(self.shape, dtype=self.dtype)
             out.fill(np.nan)
-            row, col = other.nonzero()
-            out[row, col] = 0
+            coords = other.nonzero()
+            if self.ndim == 1:
+                coords = (coords[-1],)
+            out[coords] = 0
             r = r.tocoo()
-            out[r.row, r.col] = r.data
-            out = self._container(out)
+            out[r.coords] = r.data
+            return self._container(out)
         else:
             # integers types go with nan <-> 0
             out = r
-
-        return out
+            return out
 
 
 def _process_slice(sl, num):

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -529,7 +529,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     def _matmul_sparse(self, other):
         M, K1 = self._shape_as_2d
         # if other is 1d, treat as a **column**
-        K2, N = other._shape_as_2d
+        K2, N = other._shape if other.ndim == 2 else (other.shape[0], 1)
 
         # find new_shape
         if self.ndim == 2:
@@ -540,9 +540,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         elif other.ndim == 2:
             new_shape = (N,)
         else:
-            new_shape = (1,)
+            new_shape = ()
 
-        major_axis = self._swap((M, N))[0]
+        major_dim = self._swap((M, N))[0]
         other = self.__class__(other)  # convert to this format
 
         idx_dtype = self._get_index_dtype((self.indptr, self.indices,
@@ -555,13 +555,15 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                  np.asarray(other.indptr, dtype=idx_dtype),
                  np.asarray(other.indices, dtype=idx_dtype))
         if nnz == 0:
+            if new_shape == ():
+                return np.array(0, dtype=upcast(self.dtype, other.dtype))
             return self.__class__(new_shape, dtype=upcast(self.dtype, other.dtype))
 
         idx_dtype = self._get_index_dtype((self.indptr, self.indices,
                                      other.indptr, other.indices),
                                     maxval=nnz)
 
-        indptr = np.empty(major_axis + 1, dtype=idx_dtype)
+        indptr = np.empty(major_dim + 1, dtype=idx_dtype)
         indices = np.empty(nnz, dtype=idx_dtype)
         data = np.empty(nnz, dtype=upcast(self.dtype, other.dtype))
 
@@ -574,6 +576,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
            other.data,
            indptr, indices, data)
 
+        if new_shape == ():
+            return data[0]
         return self.__class__((data, indices, indptr), shape=new_shape)
 
     def diagonal(self, k=0):
@@ -694,6 +698,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             return self.data.dtype.type(0)
         raise IndexError(f'index ({idx}) out of range')
 
+#    For now, 1d only has integer indexing. Soon we will add get_slice/array
 #    def _get_slice(self, idx):
 #        if idx == slice(None):
 #            return self.copy()

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -698,34 +698,33 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             return self.data.dtype.type(0)
         raise IndexError(f'index ({idx}) out of range')
 
-#    For now, 1d only has integer indexing. Soon we will add get_slice/array
-#    def _get_slice(self, idx):
-#        if idx == slice(None):
-#            return self.copy()
-#        if idx.step in (1, None):
-#            major, minor = self._swap((0, idx))
-#            ret = self._get_submatrix(major, minor, copy=True)
-#            return ret.reshape(ret.shape[-1])
-#
-#        _slice = self._swap((self._minor_slice, self._major_slice))[0]
-#        return _slice(idx)
-#
-#    def _get_array(self, idx):
-#        idx = np.asarray(idx)
-#        idx_dtype = self.indices.dtype
-#        M, N = self._swap((1, self.shape[0]))
-#        row = np.zeros_like(idx, dtype=idx_dtype)
-#        major, minor = self._swap((row, idx))
-#        major = np.asarray(major, dtype=idx_dtype)
-#        minor = np.asarray(minor, dtype=idx_dtype)
-#        if minor.size == 0:
-#            return self.__class__([], dtype=self.dtype)
-#        new_shape = minor.shape if minor.shape[0] > 1 else (minor.shape[-1],)
-#
-#        val = np.empty(major.size, dtype=self.dtype)
-#        csr_sample_values(M, N, self.indptr, self.indices, self.data,
-#                          major.size, major.ravel(), minor.ravel(), val)
-#        return self.__class__(val.reshape(new_shape))
+    def _get_slice(self, idx):
+        if idx == slice(None):
+            return self.copy()
+        if idx.step in (1, None):
+            major, minor = self._swap((0, idx))
+            ret = self._get_submatrix(major, minor, copy=True)
+            return ret.reshape(ret.shape[-1])
+
+        _slice = self._swap((self._minor_slice, self._major_slice))[0]
+        return _slice(idx)
+
+    def _get_array(self, idx):
+        idx = np.asarray(idx)
+        idx_dtype = self.indices.dtype
+        M, N = self._swap((1, self.shape[0]))
+        row = np.zeros_like(idx, dtype=idx_dtype)
+        major, minor = self._swap((row, idx))
+        major = np.asarray(major, dtype=idx_dtype)
+        minor = np.asarray(minor, dtype=idx_dtype)
+        if minor.size == 0:
+            return self.__class__([], dtype=self.dtype)
+        new_shape = minor.shape if minor.shape[0] > 1 else (minor.shape[-1],)
+
+        val = np.empty(major.size, dtype=self.dtype)
+        csr_sample_values(M, N, self.indptr, self.indices, self.data,
+                          major.size, major.ravel(), minor.ravel(), val)
+        return self.__class__(val.reshape(new_shape))
 
     def _get_intXint(self, row, col):
         M, N = self._swap(self.shape)

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -29,7 +29,6 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         is_array = isinstance(self, sparray)
 
         if issparse(arg1):
-            self._shape = arg1.shape
             if arg1.format == self.format and copy:
                 arg1 = arg1.copy()
             else:
@@ -90,14 +89,12 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         elif self.shape is None:
             # shape not already set, try to infer dimensions
             try:
-                major_dim = len(self.indptr) - 1
-                minor_dim = self.indices.max() + 1
+                major_d = len(self.indptr) - 1
+                minor_d = self.indices.max() + 1
             except Exception as e:
                 raise ValueError('unable to infer matrix dimensions') from e
-            else:
-                new_shape = (major_dim, minor_dim)
-                self._shape = check_shape(self._swap(new_shape),
-                                          allow_1d=is_array)
+
+            self._shape = check_shape(self._swap((major_d, minor_d)), allow_1d=is_array)
 
         if dtype is not None:
             self.data = self.data.astype(dtype, copy=False)
@@ -164,8 +161,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         M, N = self._swap(self._shape_as_2d)
 
         if (len(self.indptr) != M + 1):
-            msg = f"index pointer size ({len(self.indptr)}) should be ({M + 1})"
-            raise ValueError(msg)
+            raise ValueError(f"index pointer size {len(self.indptr)} should be {M + 1}")
         if (self.indptr[0] != 0):
             raise ValueError("index pointer should start with 0")
 
@@ -182,12 +178,11 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             # check format validity (more expensive)
             if self.nnz > 0:
                 if self.indices.max() >= N:
-                    raise ValueError(f"index values must be < {N}")
+                    raise ValueError(f"indices must be < {N}")
                 if self.indices.min() < 0:
-                    raise ValueError("index values must be >= 0")
+                    raise ValueError("indices must be >= 0")
                 if np.diff(self.indptr).min() < 0:
-                    raise ValueError("index pointer values must form a "
-                                     "non-decreasing sequence")
+                    raise ValueError("indptr must be a non-decreasing sequence")
 
             idx_dtype = self._get_index_dtype((self.indptr, self.indices))
             self.indptr = np.asarray(self.indptr, dtype=idx_dtype)
@@ -660,7 +655,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
             return ret.sum(axis=(), dtype=dtype, out=out)
         else:
-            # _spbase handles the situations when axis is in {None, -1, 0, 1}
+            # _spbase handles the situations when axis is in {None, -2, -1, 0, 1}
             return _spbase.sum(self, axis=axis, dtype=dtype, out=out)
 
     sum.__doc__ = _spbase.sum.__doc__

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -341,22 +341,22 @@ class _coo_base(_data_matrix, _minmax_mixin):
                [0, 0, 0, 1]])
 
         """
-        if self.ndim != 2:
-            raise ValueError("Cannot convert a 1d sparse array to csr format")
         if self.nnz == 0:
             return self._csr_container(self.shape, dtype=self.dtype)
         else:
-            M,N = self.shape
+            M, N = self._shape_as_2d
             idx_dtype = self._get_index_dtype(self.coords, maxval=max(self.nnz, N))
-            row = self.row.astype(idx_dtype, copy=False)
-            col = self.col.astype(idx_dtype, copy=False)
+            col = self.coords[-1].astype(idx_dtype, copy=False)
+            if self.ndim == 1:
+                row = np.zeros_like(col)
+            else:
+                row = self.coords[-2].astype(idx_dtype, copy=False)
 
             indptr = np.empty(M + 1, dtype=idx_dtype)
             indices = np.empty_like(col, dtype=idx_dtype)
             data = np.empty_like(self.data, dtype=upcast(self.dtype))
 
-            coo_tocsr(M, N, self.nnz, row, col, self.data,
-                      indptr, indices, data)
+            coo_tocsr(M, N, self.nnz, row, col, self.data, indptr, indices, data)
 
             x = self._csr_container((data, indices, indptr), shape=self.shape)
             if not self.has_canonical_format:

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -18,40 +18,6 @@ from ._compressed import _cs_matrix
 class _csr_base(_cs_matrix):
     _format = 'csr'
 
-    # override IndexMixin.__getitem__ for 1d case until fully implemented
-    def __getitem__(self, key):
-        if self.ndim == 2:
-            return super().__getitem__(key)
-
-        if isinstance(key, tuple) and len(key) == 1:
-            key = key[0]
-        INT_TYPES = (int, np.integer)
-        if isinstance(key, INT_TYPES):
-            if key < 0:
-                key += self.shape[-1]
-            if key < 0 or key >= self.shape[-1]:
-                raise IndexError('index value out of bounds')
-            return self._get_int(key)
-        else:
-            raise IndexError('array/slice index for 1d dok_array not yet supported')
-
-    # override IndexMixin.__setitem__ for 1d case until fully implemented
-    def __setitem__(self, key, value):
-        if self.ndim == 2:
-            return super().__setitem__(key, value)
-
-        if isinstance(key, tuple) and len(key) == 1:
-            key = key[0]
-        INT_TYPES = (int, np.integer)
-        if isinstance(key, INT_TYPES):
-            if key < 0:
-                key += self.shape[-1]
-            if key < 0 or key >= self.shape[-1]:
-                raise IndexError('index value out of bounds')
-            return self._set_int(key, value)
-        else:
-            raise IndexError('array index for 1d dok_array not yet provided')
-
     def transpose(self, axes=None, copy=False):
         if axes is not None and axes != (1, 0):
             raise ValueError("Sparse arrays/matrices do not support "

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -94,7 +94,9 @@ class _csr_base(_cs_matrix):
     tocsr.__doc__ = _spbase.tocsr.__doc__
 
     def tocsc(self, copy=False):
-        M, N = self._shape_as_2d
+        if self.ndim != 2:
+            raise ValueError("Cannot convert a 1d sparse array to csc format")
+        M, N = self.shape
         idx_dtype = self._get_index_dtype((self.indptr, self.indices),
                                     maxval=max(self.nnz, M))
         indptr = np.empty(N + 1, dtype=idx_dtype)
@@ -176,9 +178,8 @@ class _csr_base(_cs_matrix):
         indptr = np.zeros(2, dtype=self.indptr.dtype)
         # return 1d (sparray) or 2drow (spmatrix)
         shape = self.shape[1:] if isinstance(self, sparray) else (1, self.shape[1])
-        idxiter = iter(self.indptr)
-        i0 = next(idxiter)
-        for i1 in idxiter:
+        i0 = 0
+        for i1 in self.indptr[1:]:
             indptr[1] = i1 - i0
             indices = self.indices[i0:i1]
             data = self.data[i0:i1]
@@ -206,10 +207,11 @@ class _csr_base(_cs_matrix):
                               dtype=self.dtype, copy=False)
 
     def _getcol(self, i):
-        """Returns a copy of column i of the matrix, as a (m x 1)
-        CSR matrix (column vector).
+        """Returns a copy of column i. A (m x 1) sparse array (column vector).
         """
-        M, N = self._shape_as_2d
+        if self.ndim == 1:
+            raise ValueError("getcol not provided for 1d arrays. Use indexing A[j]")
+        M, N = self.shape
         i = int(i)
         if i < 0:
             i += N

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -18,12 +18,48 @@ from ._compressed import _cs_matrix
 class _csr_base(_cs_matrix):
     _format = 'csr'
 
+    # override IndexMixin.__getitem__ for 1d case until fully implemented
+    def __getitem__(self, key):
+        if self.ndim == 2:
+            return super().__getitem__(key)
+
+        if isinstance(key, tuple) and len(key) == 1:
+            key = key[0]
+        INT_TYPES = (int, np.integer)
+        if isinstance(key, INT_TYPES):
+            if key < 0:
+                key += self.shape[-1]
+            if key < 0 or key >= self.shape[-1]:
+                raise IndexError('index value out of bounds')
+            return self._get_int(key)
+        else:
+            raise IndexError('array/slice index for 1d dok_array not yet supported')
+
+    # override IndexMixin.__setitem__ for 1d case until fully implemented
+    def __setitem__(self, key, value):
+        if self.ndim == 2:
+            return super().__setitem__(key, value)
+
+        if isinstance(key, tuple) and len(key) == 1:
+            key = key[0]
+        INT_TYPES = (int, np.integer)
+        if isinstance(key, INT_TYPES):
+            if key < 0:
+                key += self.shape[-1]
+            if key < 0 or key >= self.shape[-1]:
+                raise IndexError('index value out of bounds')
+            return self._set_int(key, value)
+        else:
+            raise IndexError('array index for 1d dok_array not yet provided')
+
     def transpose(self, axes=None, copy=False):
         if axes is not None and axes != (1, 0):
             raise ValueError("Sparse arrays/matrices do not support "
                               "an 'axes' parameter because swapping "
                               "dimensions is the only logical permutation.")
 
+        if self.ndim == 1:
+            return self.copy() if copy else self
         M, N = self.shape
         return self._csc_container((self.data, self.indices,
                                     self.indptr), shape=(N, M), copy=copy)
@@ -31,6 +67,8 @@ class _csr_base(_cs_matrix):
     transpose.__doc__ = _spbase.transpose.__doc__
 
     def tolil(self, copy=False):
+        if self.ndim != 2:
+            raise ValueError("Cannot convert a 1d sparse array to lil format")
         lil = self._lil_container(self.shape, dtype=self.dtype)
 
         self.sum_duplicates()
@@ -56,13 +94,14 @@ class _csr_base(_cs_matrix):
     tocsr.__doc__ = _spbase.tocsr.__doc__
 
     def tocsc(self, copy=False):
+        M, N = self._shape_as_2d
         idx_dtype = self._get_index_dtype((self.indptr, self.indices),
-                                    maxval=max(self.nnz, self.shape[0]))
-        indptr = np.empty(self.shape[1] + 1, dtype=idx_dtype)
+                                    maxval=max(self.nnz, M))
+        indptr = np.empty(N + 1, dtype=idx_dtype)
         indices = np.empty(self.nnz, dtype=idx_dtype)
         data = np.empty(self.nnz, dtype=upcast(self.dtype))
 
-        csr_tocsc(self.shape[0], self.shape[1],
+        csr_tocsc(M, N,
                   self.indptr.astype(idx_dtype),
                   self.indices.astype(idx_dtype),
                   self.data,
@@ -77,6 +116,8 @@ class _csr_base(_cs_matrix):
     tocsc.__doc__ = _spbase.tocsc.__doc__
 
     def tobsr(self, blocksize=None, copy=True):
+        if self.ndim != 2:
+            raise ValueError("Cannot convert a 1d sparse array to bsr format")
         if blocksize is None:
             from ._spfuncs import estimate_blocksize
             return self.tobsr(blocksize=estimate_blocksize(self))
@@ -120,22 +161,39 @@ class _csr_base(_cs_matrix):
         return x
 
     def __iter__(self):
+        if self.ndim == 1:
+            zero = self.dtype.type(0)
+            u = 0
+            for v, d in zip(self.indices, self.data):
+                for _ in range(v - u):
+                    yield zero
+                yield d
+                u = v + 1
+            for _ in range(self.shape[0] - u):
+                yield zero
+            return
+
         indptr = np.zeros(2, dtype=self.indptr.dtype)
-        shape = (1, self.shape[1])
-        i0 = 0
-        for i1 in self.indptr[1:]:
+        # return 1d (sparray) or 2drow (spmatrix)
+        shape = self.shape[1:] if isinstance(self, sparray) else (1, self.shape[1])
+        idxiter = iter(self.indptr)
+        i0 = next(idxiter)
+        for i1 in idxiter:
             indptr[1] = i1 - i0
             indices = self.indices[i0:i1]
             data = self.data[i0:i1]
-            yield self.__class__(
-                (data, indices, indptr), shape=shape, copy=True
-            )
+            yield self.__class__((data, indices, indptr), shape=shape, copy=True)
             i0 = i1
 
     def _getrow(self, i):
         """Returns a copy of row i of the matrix, as a (1 x n)
         CSR matrix (row vector).
         """
+        if self.ndim == 1:
+            if i not in (0, -1):
+                raise IndexError(f'index ({i}) out of range')
+            return self.reshape((1, self.shape[0]), copy=True)
+
         M, N = self.shape
         i = int(i)
         if i < 0:
@@ -151,7 +209,7 @@ class _csr_base(_cs_matrix):
         """Returns a copy of column i of the matrix, as a (m x 1)
         CSR matrix (column vector).
         """
-        M, N = self.shape
+        M, N = self._shape_as_2d
         i = int(i)
         if i < 0:
             i += N

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -2,6 +2,7 @@
 """
 import numpy as np
 from ._sputils import isintlike
+from ._base import sparray, issparse
 
 INT_TYPES = (int, np.integer)
 
@@ -33,8 +34,6 @@ class IndexMixin:
 
         Once 1D sparse arrays are implemented, it should be removed.
         """
-        from scipy.sparse import sparray
-
         if isinstance(self, sparray):
             raise NotImplementedError(
                 'We have not yet implemented 1D sparse slices; '
@@ -42,6 +41,18 @@ class IndexMixin:
             )
 
     def __getitem__(self, key):
+        # handle 1d indexing
+        if self.ndim == 1:
+            idx = self._validate_indices(key)
+            if isinstance(idx, tuple) and len(idx) == 1:
+                idx = idx[0]
+            if isinstance(idx, INT_TYPES):
+                return self._get_int(idx)
+            elif isinstance(idx, slice):
+                return self._get_slice(idx)
+            # assume array idx
+            return self._get_array(idx)
+
         row, col = self._validate_indices(key)
 
         # Dispatch to specialized methods.
@@ -92,6 +103,33 @@ class IndexMixin:
         return self._get_arrayXarray(row, col)
 
     def __setitem__(self, key, x):
+        # handle 1d indexing
+        if self.ndim == 1:
+            idx = self._validate_indices(key)
+            if isinstance(idx, INT_TYPES):
+                x = np.asarray(x, dtype=self.dtype)
+                if x.size != 1:
+                    raise ValueError('Trying to assign a sequence to an item')
+                self._set_int(idx, x.flat[0])
+                return
+
+            if isinstance(idx, slice):
+                idx = np.arange(*idx.indices(self.shape[0]))
+            else:
+                idx = np.atleast_1d(idx)
+
+            # broadcast scalar to full 1d
+            if issparse(x):
+                x = x.toarray()
+            x = np.asarray(x, dtype=self.dtype)
+            if x.squeeze().shape != idx.squeeze().shape:
+                x = np.broadcast_to(x, idx.shape)
+            if x.size == 0:
+                return
+            x = x.reshape(idx.shape)
+            self._set_array(idx, x)
+            return
+
         row, col = self._validate_indices(key)
 
         if isinstance(row, INT_TYPES) and isinstance(col, INT_TYPES):
@@ -117,7 +155,6 @@ class IndexMixin:
         if i.shape != j.shape:
             raise IndexError('number of row and column indices differ')
 
-        from ._base import issparse
         if issparse(x):
             if i.ndim == 1:
                 # Inner indexing, so treat them like row vectors.
@@ -144,28 +181,56 @@ class IndexMixin:
             self._set_arrayXarray(i, j, x)
 
     def _validate_indices(self, key):
-        M, N = self.shape
-        row, col = _unpack_index(key)
+        # single boolean matrix
+        if ((issparse(key) or isinstance(key, np.ndarray)) and
+                key.ndim == self.ndim and key.dtype.kind == 'b'):
+            for keyN, N in zip(key.shape, self._shape):
+                if keyN > N:
+                    raise IndexError("index shape bigger than indexed array")
+            idx = key.nonzero()
+            if self.ndim == 1 and len(idx) > 1:
+                idx = (idx[-1],)
+            index = [self._asindices(ix, N) for N, ix in zip(self.shape, idx)]
+            return tuple(index)
 
-        if isintlike(row):
-            row = int(row)
-            if row < -M or row >= M:
-                raise IndexError('row index (%d) out of range' % row)
-            if row < 0:
-                row += M
-        elif not isinstance(row, slice):
-            row = self._asindices(row, M)
+        # single integer
+        if isinstance(key, INT_TYPES):
+            N = self.shape[0]
+            idx = int(key)
+            if idx < -N or idx >= N:
+                raise IndexError('index (%d) out of range' % idx)
+            if idx < 0:
+                idx += N
+            return idx if self.ndim == 1 else (idx, slice(None))
 
-        if isintlike(col):
-            col = int(col)
-            if col < -N or col >= N:
-                raise IndexError('column index (%d) out of range' % col)
-            if col < 0:
-                col += N
-        elif not isinstance(col, slice):
-            col = self._asindices(col, N)
+        # single slice
+        if isinstance(key, slice):
+            return key if self.ndim == 1 else (key, slice(None))
 
-        return row, col
+        # single ellipsis
+        if key is Ellipsis:
+            return (slice(None),) * self.ndim
+
+        # form a tuple
+        indices = _unpack_index(key, self.shape)
+
+        if len(self.shape) != len(indices):
+            raise IndexError("invalid number of indices")
+        new_indices = []
+        for N, idx in zip(self.shape, indices):
+            if isintlike(idx):
+                idx = int(idx)
+                if idx < -N or idx >= N:
+                    raise IndexError('row index (%d) out of range' % idx)
+                if idx < 0:
+                    idx += N
+            elif not isinstance(idx, slice):
+                idx = self._asindices(idx, N)
+            new_indices.append(idx)
+
+        if self.ndim == 1:
+            return new_indices[0]
+        return tuple(new_indices)
 
     def _asindices(self, idx, length):
         """Convert `idx` to a valid index for an axis with a given length.
@@ -196,6 +261,15 @@ class IndexMixin:
                 x = x.copy()
             x[x < 0] += length
         return x
+
+    def _get_int(self, idx):
+        raise NotImplementedError()
+
+    def _get_slice(self, idx):
+        raise NotImplementedError()
+
+    def _get_array(self, idx):
+        raise NotImplementedError()
 
     def _getrow(self, i):
         """Return a copy of row i of the matrix, as a (1 x n) row vector.
@@ -262,95 +336,85 @@ class IndexMixin:
         self._set_arrayXarray(row, col, x)
 
 
-def _unpack_index(index):
-    """ Parse index. Always return a tuple of the form (row, col).
-    Valid type for row/col is integer, slice, or array of integers.
+def _unpack_index(index, desired_shape):
+    """ Parse index. Always return a ndim-tuple where each item
+    is integer, slice, or array of integers.
     """
-    # First, check if indexing with single boolean matrix.
-    from ._base import _spbase, issparse
-    if (isinstance(index, (_spbase, np.ndarray)) and
-            index.ndim == 2 and index.dtype.kind == 'b'):
-        return index.nonzero()
-
-    # Parse any ellipses.
-    index = _check_ellipsis(index)
-
-    # Next, parse the tuple or object
+    desired_ndim = len(desired_shape)
     if isinstance(index, tuple):
-        if len(index) == 2:
-            row, col = index
-        elif len(index) == 1:
-            row, col = index[0], slice(None)
-        else:
-            raise IndexError('invalid number of indices')
+        # handle Ellipsis inside tuple
+        ellipsis_indices = [i for i, v in enumerate(index) if v is Ellipsis]
+        if ellipsis_indices:
+            if len(ellipsis_indices) > 1:
+                raise IndexError("an index can only have a single ellipsis ('...')")
+            first_ell = ellipsis_indices[0]
+
+            # handle common cases
+            # len(index) == 1 handled before this function
+            if len(index) == 2:
+                if first_ell == 0:
+                    ix = index[1] if 1 not in ellipsis_indices else slice(None)
+                    index = (slice(None), ix)
+                else:
+                    index = (index[0], slice(None))
+            # handle uncommon cases
+            else:
+                tail = [v for v in index[first_ell + 1:] if v is not Ellipsis]
+                nd = first_ell + len(tail)
+                nslice = max(0, desired_ndim - nd)
+                index = index[:first_ell] + (slice(None),) * nslice + tuple(tail)
+
+        # pad tuples
+        if len(index) < desired_ndim:
+            index = index + (slice(None),) * (desired_ndim - len(index))
+
+    # handle non-tuples
     else:
-        idx = _compatible_boolean_index(index)
+        idx = _compatible_boolean_index(index)  # _compatible_boolean_array??
         if idx is None:
-            row, col = index, slice(None)
-        elif idx.ndim < 2:
-            return _boolean_index_to_array(idx), slice(None)
-        elif idx.ndim == 2:
-            return idx.nonzero()
-    # Next, check for validity and transform the index as needed.
-    if issparse(row) or issparse(col):
-        # Supporting sparse boolean indexing with both row and col does
-        # not work because spmatrix.ndim is always 2.
-        raise IndexError(
-            'Indexing with sparse matrices is not supported '
-            'except boolean indexing where matrix and index '
-            'are equal shapes.')
-    bool_row = _compatible_boolean_index(row)
-    bool_col = _compatible_boolean_index(col)
-    if bool_row is not None:
-        row = _boolean_index_to_array(bool_row)
-    if bool_col is not None:
-        col = _boolean_index_to_array(bool_col)
-    return row, col
+            # not a boolean array. Pad with :
+            index = (index,) + (slice(None),) * (desired_ndim - 1)
+        elif idx.ndim <= desired_ndim:
+            for i, (idim, sdim) in enumerate(zip(idx.shape, desired_shape)):
+                if idim != sdim:
+                   raise IndexError("boolean index did not match index array "
+                                    f"along dimension {i}; dimension is {sdim} "
+                                    f"but corresponding boolean dimension is {idim}"
+                                    )
+            if idx.ndim == desired_ndim:
+                return idx.nonzero()
+            index = (index,) + (slice(None),) * (desired_ndim - idx.ndim)
+        else:
+            raise IndexError('invalid ndim for array index')
 
-
-def _check_ellipsis(index):
-    """Process indices with Ellipsis. Returns modified index."""
-    if index is Ellipsis:
-        return (slice(None), slice(None))
-
-    if not isinstance(index, tuple):
-        return index
-
-    # Find any Ellipsis objects.
-    ellipsis_indices = [i for i, v in enumerate(index) if v is Ellipsis]
-    if not ellipsis_indices:
-        return index
-    if len(ellipsis_indices) > 1:
-        raise IndexError("an index can only have a single ellipsis ('...')")
-
-    # Replace the Ellipsis object with 0, 1, or 2 null-slices as needed.
-    i, = ellipsis_indices
-    num_slices = max(0, 3 - len(index))
-    return index[:i] + (slice(None),) * num_slices + index[i + 1:]
-
-
-def _maybe_bool_ndarray(idx):
-    """Returns a compatible array if elements are boolean.
-    """
-    idx = np.asanyarray(idx)
-    if idx.dtype.kind == 'b':
-        return idx
-    return None
-
+    # process each dimension of the index
+    new_index = []
+    for idx in index:
+        if issparse(idx):
+            # TODO: make sparse matrix indexing work for sparray
+            raise IndexError(
+                'Indexing with sparse matrices is not supported '
+                'except boolean indexing where matrix and index '
+                'are equal shapes.')
+        bool_idx = _compatible_boolean_index(idx)
+        if bool_idx is not None:
+            if bool_idx.ndim > 1:
+                raise IndexError('invalid index shape')
+            idx = np.where(idx)[0]
+        new_index.append(idx)
+    return tuple(new_index)
 
 def _first_element_bool(idx, max_dim=2):
-    """Returns True if first element of the incompatible
-    array type is boolean.
+    """Returns True if first element of the non-ndim array is boolean.
     """
-    if max_dim < 1:
-        return None
+    print("In first_element_bool. idx: ", idx)
     try:
-        first = next(iter(idx), None)
+        for _ in range(max_dim + 1):
+            if isinstance(idx, bool):
+                return True
+            idx = next(iter(idx), None)
     except TypeError:
         return None
-    if isinstance(first, bool):
-        return True
-    return _first_element_bool(first, max_dim-1)
 
 
 def _compatible_boolean_index(idx):
@@ -359,11 +423,20 @@ def _compatible_boolean_index(idx):
     """
     # Presence of attribute `ndim` indicates a compatible array type.
     if hasattr(idx, 'ndim') or _first_element_bool(idx):
-        return _maybe_bool_ndarray(idx)
-    return None
-
-
-def _boolean_index_to_array(idx):
-    if idx.ndim > 1:
-        raise IndexError('invalid index shape')
-    return np.where(idx)[0]
+        idx = np.asanyarray(idx)
+        if idx.dtype.kind == 'b':
+            ret = idx
+        else:
+            ret = None
+    else:
+        ret = None
+    ############### Try a different way
+    idx = np.asanyarray(idx)
+    if idx.dtype.kind == 'b':
+        ret2 = idx
+        print("ret, ret2:", ret,ret2)
+        assert np.array_equal(ret, ret2)
+    else:
+        ret2 = None
+        assert ret == ret2
+    return ret

--- a/scipy/sparse/tests/meson.build
+++ b/scipy/sparse/tests/meson.build
@@ -1,5 +1,6 @@
 python_sources = [
   '__init__.py',
+  'test_arithmetic1d.py',
   'test_array_api.py',
   'test_base.py',
   'test_coo.py',

--- a/scipy/sparse/tests/meson.build
+++ b/scipy/sparse/tests/meson.build
@@ -10,6 +10,7 @@ python_sources = [
   'test_csc.py',
   'test_csr.py',
   'test_extract.py',
+  'test_indexing1d.py',
   'test_matrix_io.py',
   'test_minmax1d.py',
   'test_sparsetools.py',

--- a/scipy/sparse/tests/test_arithmetic1d.py
+++ b/scipy/sparse/tests/test_arithmetic1d.py
@@ -289,8 +289,7 @@ class TestArithmetic1D:
             assert np.array_equal(sum2, dat + dat)
 
     def test_size_zero_matrix_arithmetic(self, spcreator):
-        # Test basic matrix arithmetic with shapes like 0, (1, 0),
-        # (0, 3), etc.
+        # Test basic matrix arithmetic with shapes like 0, (1, 0), (0, 3), etc.
         mat = np.array([])
         a = mat.reshape(0)
         d = mat.reshape((1, 0))
@@ -322,5 +321,3 @@ class TestArithmetic1D:
 
         # Addition
         assert np.array_equal(asp.__add__(asp).toarray(), a.__add__(a))
-
-

--- a/scipy/sparse/tests/test_arithmetic1d.py
+++ b/scipy/sparse/tests/test_arithmetic1d.py
@@ -45,11 +45,10 @@ class TestArithmetic1D:
             a = spcreator(shape, dtype=mytype)
             b = a + a
             c = 2 * a
-            d = a @ a.tocsr()
-            e = a @ a.tocoo()
-            for m in [a, b, c, d, e]:
-                a_matmul_a = a.toarray() @ a.toarray()
-                assert not (m @ m != a_matmul_a).nnz
+            assert isinstance(a @ a.tocsr(), np.ndarray)
+            assert isinstance(a @ a.tocoo(), np.ndarray)
+            for m in [a, b, c]:
+                assert m @ m == a.toarray() @ a.toarray()
                 assert np.array_equal(m.dtype, mytype)
                 assert np.array_equal(toarray(m).dtype, mytype)
 
@@ -302,7 +301,8 @@ class TestArithmetic1D:
             asp.__add__(dsp)
 
         # matrix product.
-        assert np.equal(asp.dot(asp).toarray()[0], np.dot(a, a))
+        assert isinstance(asp.dot(asp), np.ndarray)
+        assert np.equal(asp.dot(asp), np.dot(a, a))
 
         # bad matrix products
         with pytest.raises(ValueError, match='dimension mismatch'):

--- a/scipy/sparse/tests/test_arithmetic1d.py
+++ b/scipy/sparse/tests/test_arithmetic1d.py
@@ -1,0 +1,326 @@
+"""Test of 1D arithmetic operations"""
+
+import pytest
+
+import numpy as np
+
+from scipy.sparse import coo_array, csr_array
+from scipy.sparse._sputils import isscalarlike
+
+
+spcreators = [coo_array, csr_array]
+math_dtypes = [np.int64, np.float64, np.complex128]
+
+
+def toarray(a):
+    if isinstance(a, np.ndarray) or isscalarlike(a):
+        return a
+    return a.toarray()
+
+@pytest.fixture
+def dat1d():
+    return np.array([3, 0, 1, 0], 'd')
+
+
+@pytest.fixture
+def datsp_math_dtypes(dat1d):
+    dat_dtypes = {dtype: dat1d.astype(dtype) for dtype in math_dtypes}
+    return {
+        sp: [(dtype, dat, sp(dat)) for dtype, dat in dat_dtypes.items()]
+        for sp in spcreators
+    }
+
+
+@pytest.mark.parametrize("spcreator", spcreators)
+class TestArithmetic1D:
+    def test_empty_arithmetic(self, spcreator):
+        shape = (5,)
+        for mytype in [
+            np.dtype('int32'),
+            np.dtype('float32'),
+            np.dtype('float64'),
+            np.dtype('complex64'),
+            np.dtype('complex128'),
+        ]:
+            a = spcreator(shape, dtype=mytype)
+            b = a + a
+            c = 2 * a
+            d = a @ a.tocsr()
+            e = a @ a.tocoo()
+            for m in [a, b, c, d, e]:
+                a_matmul_a = a.toarray() @ a.toarray()
+                assert not (m @ m != a_matmul_a).nnz
+                assert np.array_equal(m.dtype, mytype)
+                assert np.array_equal(toarray(m).dtype, mytype)
+
+    def test_abs(self, spcreator):
+        A = np.array([-1, 0, 17, 0, -5, 0, 1, -4, 0, 0, 0, 0], 'd')
+        assert np.array_equal(abs(A), abs(spcreator(A)).toarray())
+
+    def test_round(self, spcreator):
+        A = np.array([-1.35, 0.56, 17.25, -5.98], 'd')
+        Asp = spcreator(A)
+        assert np.array_equal(np.around(A, decimals=1), round(Asp, ndigits=1).toarray())
+
+    def test_elementwise_power(self, spcreator):
+        A = np.array([-4, -3, -2, -1, 0, 1, 2, 3, 4], 'd')
+        Asp = spcreator(A)
+        assert np.array_equal(np.power(A, 2), Asp.power(2).toarray())
+
+        # element-wise power function needs a scalar power
+        with pytest.raises(NotImplementedError, match='input is not scalar'):
+            spcreator(A).power(A)
+
+    def test_real(self, spcreator):
+        D = np.array([1 + 3j, 2 - 4j])
+        A = spcreator(D)
+        assert np.array_equal(A.real.toarray(), D.real)
+
+    def test_imag(self, spcreator):
+        D = np.array([1 + 3j, 2 - 4j])
+        A = spcreator(D)
+        assert np.array_equal(A.imag.toarray(), D.imag)
+
+    def test_mul_scalar(self, spcreator, datsp_math_dtypes):
+        for dtype, dat, datsp in datsp_math_dtypes[spcreator]:
+            assert np.array_equal(dat * 2, (datsp * 2).toarray())
+            assert np.array_equal(dat * 17.3, (datsp * 17.3).toarray())
+
+    def test_rmul_scalar(self, spcreator, datsp_math_dtypes):
+        for dtype, dat, datsp in datsp_math_dtypes[spcreator]:
+            assert np.array_equal(2 * dat, (2 * datsp).toarray())
+            assert np.array_equal(17.3 * dat, (17.3 * datsp).toarray())
+
+    def test_sub(self, spcreator, datsp_math_dtypes):
+        for dtype, dat, datsp in datsp_math_dtypes[spcreator]:
+            if dtype == np.dtype('bool'):
+                # boolean array subtraction deprecated in 1.9.0
+                continue
+
+            assert np.array_equal((datsp - datsp).toarray(), np.zeros(4))
+            assert np.array_equal((datsp - 0).toarray(), dat)
+
+            A = spcreator([1, -4, 0, 2], dtype='d')
+            assert np.array_equal((datsp - A).toarray(), dat - A.toarray())
+            assert np.array_equal((A - datsp).toarray(), A.toarray() - dat)
+
+            # test broadcasting
+            assert np.array_equal(datsp.toarray() - dat[0], dat - dat[0])
+
+    def test_add0(self, spcreator, datsp_math_dtypes):
+        for dtype, dat, datsp in datsp_math_dtypes[spcreator]:
+            # Adding 0 to a sparse matrix
+            assert np.array_equal((datsp + 0).toarray(), dat)
+            # use sum (which takes 0 as a starting value)
+            sumS = sum([k * datsp for k in range(1, 3)])
+            sumD = sum([k * dat for k in range(1, 3)])
+            assert np.allclose(sumS.toarray(), sumD)
+
+    def test_elementwise_multiply(self, spcreator):
+        # real/real
+        A = np.array([4, 0, 9])
+        B = np.array([0, 7, -1])
+        Asp = spcreator(A)
+        Bsp = spcreator(B)
+        assert np.allclose(Asp.multiply(Bsp).toarray(), A * B)  # sparse/sparse
+        assert np.allclose(Asp.multiply(B).toarray(), A * B)  # sparse/dense
+
+        # complex/complex
+        C = np.array([1 - 2j, 0 + 5j, -1 + 0j])
+        D = np.array([5 + 2j, 7 - 3j, -2 + 1j])
+        Csp = spcreator(C)
+        Dsp = spcreator(D)
+        assert np.allclose(Csp.multiply(Dsp).toarray(), C * D)  # sparse/sparse
+        assert np.allclose(Csp.multiply(D).toarray(), C * D)  # sparse/dense
+
+        # real/complex
+        assert np.allclose(Asp.multiply(Dsp).toarray(), A * D)  # sparse/sparse
+        assert np.allclose(Asp.multiply(D).toarray(), A * D)  # sparse/dense
+
+    def test_elementwise_multiply_broadcast(self, spcreator):
+        A = np.array([4])
+        B = np.array([[-9]])
+        C = np.array([1, -1, 0])
+        D = np.array([[7, 9, -9]])
+        E = np.array([[3], [2], [1]])
+        F = np.array([[8, 6, 3], [-4, 3, 2], [6, 6, 6]])
+        G = [1, 2, 3]
+        H = np.ones((3, 4))
+        J = H.T
+        K = np.array([[0]])
+        L = np.array([[[1, 2], [0, 1]]])
+
+        # Some arrays can't be cast as spmatrices (A, C, L) so leave
+        # them out.
+        Asp = spcreator(A)
+        Csp = spcreator(C)
+        Gsp = spcreator(G)
+        # 2d arrays
+        Bsp = spcreator(B)
+        Dsp = spcreator(D)
+        Esp = spcreator(E)
+        Fsp = spcreator(F)
+        Hsp = spcreator(H)
+        Hspp = spcreator(H[0, None])
+        Jsp = spcreator(J)
+        Jspp = spcreator(J[:, 0, None])
+        Ksp = spcreator(K)
+
+        matrices = [A, B, C, D, E, F, G, H, J, K, L]
+        spmatrices = [Asp, Bsp, Csp, Dsp, Esp, Fsp, Gsp, Hsp, Hspp, Jsp, Jspp, Ksp]
+        sp1dmatrices = [Asp, Csp, Gsp]
+
+        # sparse/sparse
+        for i in sp1dmatrices:
+            for j in spmatrices:
+                try:
+                    dense_mult = i.toarray() * j.toarray()
+                except ValueError:
+                    with pytest.raises(ValueError, match='inconsistent shapes'):
+                        i.multiply(j)
+                    continue
+                sp_mult = i.multiply(j)
+                assert np.allclose(sp_mult.toarray(), dense_mult)
+
+        # sparse/dense
+        for i in sp1dmatrices:
+            for j in matrices:
+                try:
+                    dense_mult = i.toarray() * j
+                except TypeError:
+                    continue
+                except ValueError:
+                    matchme = 'broadcast together|inconsistent shapes'
+                    with pytest.raises(ValueError, match=matchme):
+                        i.multiply(j)
+                    continue
+                sp_mult = i.multiply(j)
+                assert np.allclose(toarray(sp_mult), dense_mult)
+
+    def test_elementwise_divide(self, spcreator, dat1d):
+        datsp = spcreator(dat1d)
+        expected = np.array([1, np.nan, 1, np.nan])
+        actual = datsp / datsp
+        # need assert_array_equal to handle nan values
+        np.testing.assert_array_equal(actual, expected)
+
+        denom = spcreator([1, 0, 0, 4], dtype='d')
+        expected = [3, np.nan, np.inf, 0]
+        np.testing.assert_array_equal(datsp / denom, expected)
+
+        # complex
+        A = np.array([1 - 2j, 0 + 5j, -1 + 0j])
+        B = np.array([5 + 2j, 7 - 3j, -2 + 1j])
+        Asp = spcreator(A)
+        Bsp = spcreator(B)
+        assert np.allclose(Asp / Bsp, A / B)
+
+        # integer
+        A = np.array([1, 2, 3])
+        B = np.array([0, 1, 2])
+        Asp = spcreator(A)
+        Bsp = spcreator(B)
+        with np.errstate(divide='ignore'):
+            assert np.array_equal(Asp / Bsp, A / B)
+
+        # mismatching sparsity patterns
+        A = np.array([0, 1])
+        B = np.array([1, 0])
+        Asp = spcreator(A)
+        Bsp = spcreator(B)
+        with np.errstate(divide='ignore', invalid='ignore'):
+            assert np.array_equal(Asp / Bsp, A / B)
+
+    def test_pow(self, spcreator):
+        A = np.array([1, 0, 2, 0])
+        B = spcreator(A)
+
+        # unusual exponents
+        with pytest.raises(ValueError, match='negative integer powers'):
+            B**-1
+        with pytest.raises(NotImplementedError, match='zero power'):
+            B**0
+
+        for exponent in [1, 2, 3, 2.2]:
+            ret_sp = B**exponent
+            ret_np = A**exponent
+            assert np.array_equal(ret_sp.toarray(), ret_np)
+            assert np.array_equal(ret_sp.dtype, ret_np.dtype)
+
+    def test_dot_scalar(self, spcreator, dat1d):
+        A = spcreator(dat1d)
+        scalar = 10
+        actual = A.dot(scalar)
+        expected = A * scalar
+
+        assert np.allclose(actual.toarray(), expected.toarray())
+
+    def test_matmul(self, spcreator):
+        M = spcreator([2, 0, 3.0])
+        B = spcreator(np.array([[0, 1], [1, 0], [0, 2]], 'd'))
+        col = np.array([[1, 2, 3]]).T
+
+        # check matrix-vector
+        assert np.allclose(M @ col, M.toarray() @ col)
+
+        # check matrix-matrix
+        assert np.allclose((M @ B).toarray(), (M @ B).toarray())
+        assert np.allclose(M.toarray() @ B, (M @ B).toarray())
+        assert np.allclose(M @ B.toarray(), (M @ B).toarray())
+
+        # check error on matrix-scalar
+        with pytest.raises(ValueError, match='Scalar operands are not allowed'):
+            M @ 1
+        with pytest.raises(ValueError, match='Scalar operands are not allowed'):
+            1 @ M
+
+    def test_sub_dense(self, spcreator, datsp_math_dtypes):
+        # subtracting a dense matrix to/from a sparse matrix
+        for dtype, dat, datsp in datsp_math_dtypes[spcreator]:
+            if dtype == np.dtype('bool'):
+                # boolean array subtraction deprecated in 1.9.0
+                continue
+
+            # Manually add to avoid upcasting from scalar
+            # multiplication.
+            sum1 = (dat + dat + dat) - datsp
+            assert np.array_equal(sum1, dat + dat)
+            sum2 = (datsp + datsp + datsp) - dat
+            assert np.array_equal(sum2, dat + dat)
+
+    def test_size_zero_matrix_arithmetic(self, spcreator):
+        # Test basic matrix arithmetic with shapes like 0, (1, 0),
+        # (0, 3), etc.
+        mat = np.array([])
+        a = mat.reshape(0)
+        d = mat.reshape((1, 0))
+        f = np.ones([5, 5])
+
+        asp = spcreator(a)
+        dsp = spcreator(d)
+        # bad shape for addition
+        with pytest.raises(ValueError, match='inconsistent shapes'):
+            asp.__add__(dsp)
+
+        # matrix product.
+        assert np.equal(asp.dot(asp).toarray()[0], np.dot(a, a))
+
+        # bad matrix products
+        with pytest.raises(ValueError, match='dimension mismatch'):
+            asp.dot(f)
+
+        # elemente-wise multiplication
+        assert np.array_equal(asp.multiply(asp).toarray(), np.multiply(a, a))
+
+        assert np.array_equal(asp.multiply(a).toarray(), np.multiply(a, a))
+
+        assert np.array_equal(asp.multiply(6).toarray(), np.multiply(a, 6))
+
+        # bad element-wise multiplication
+        with pytest.raises(ValueError, match='inconsistent shapes'):
+            asp.multiply(f)
+
+        # Addition
+        assert np.array_equal(asp.__add__(asp).toarray(), a.__add__(a))
+
+

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3009,7 +3009,7 @@ class _TestFancyIndexing:
         Z3 = np.zeros((6, 11), dtype=bool)
         Z3[-1,0] = True
 
-        assert_equal(A[Z1], np.array([]))
+        assert_raises(IndexError, A.__getitem__, Z1)
         assert_raises(IndexError, A.__getitem__, Z2)
         assert_raises(IndexError, A.__getitem__, Z3)
         assert_raises((IndexError, ValueError), A.__getitem__, (X, 1))

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -404,15 +404,13 @@ class TestGetSet1D:  # skip name check
             assert np.array_equal(A[j], D[j])
 
         for ij in [3, -4]:
-            with pytest.raises(
-                (IndexError, TypeError), match='index value out of bounds'
-            ):
+            with pytest.raises(IndexError, match='index (.*) out of range'):
                 A.__getitem__(ij)
 
         # single element tuples unwrapped
         assert A[(0,)] == 4
 
-        with pytest.raises(IndexError, match='index value out of bounds'):
+        with pytest.raises(IndexError, match='index (.*) out of range'):
             A.__getitem__((4,))
 
     def test_setelement(self, spcreator):
@@ -433,5 +431,5 @@ class TestGetSet1D:  # skip name check
             A[1,] = dtype(5)  # overwrite using 1-tuple index
 
             for ij in [13, -14, (13,), (14,)]:
-                with pytest.raises(IndexError, match='index value out of bounds'):
+                with pytest.raises(IndexError, match='index (.*) out of range'):
                     A.__setitem__(ij, 123.0)

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -5,6 +5,7 @@ import pytest
 import numpy as np
 
 import scipy as sp
+from scipy.sparse import coo_array, csr_array
 from scipy.sparse._sputils import supported_dtypes, matrix
 from scipy._lib._util import ComplexWarning
 
@@ -13,7 +14,7 @@ sup_complex = np.testing.suppress_warnings()
 sup_complex.filter(ComplexWarning)
 
 
-spcreators = [sp.sparse.coo_array]
+spcreators = [coo_array, csr_array]
 math_dtypes = [np.int64, np.float64, np.complex128]
 
 
@@ -145,11 +146,6 @@ class TestCommon1D:
     def test_mean_invalid_params(self, spcreator):
         out = np.asarray(np.zeros((1, 3)))
         dat = np.array([[0, 1, 2], [3, -4, 5], [-6, 7, 9]])
-
-        if spcreator._format == 'uni':
-            with pytest.raises(ValueError, match='zq'):
-                spcreator(dat)
-            return
 
         datsp = spcreator(dat)
         with pytest.raises(ValueError, match='axis out of range'):
@@ -395,3 +391,47 @@ class TestCommon1D:
         assert np.array_equal(S.toarray(), [1, 0, 3])
         S.resize((5,))
         assert np.array_equal(S.toarray(), [1, 0, 3, 0, 0])
+
+
+@pytest.mark.parametrize("spcreator", [csr_array])
+class TestGetSet1D:  # skip name check
+    def test_getelement(self, spcreator):
+        D = np.array([4, 3, 0])
+        A = spcreator(D)
+
+        N = D.shape[0]
+        for j in range(-N, N):
+            assert np.array_equal(A[j], D[j])
+
+        for ij in [3, -4]:
+            with pytest.raises(
+                (IndexError, TypeError), match='index value out of bounds'
+            ):
+                A.__getitem__(ij)
+
+        # single element tuples unwrapped
+        assert A[(0,)] == 4
+
+        with pytest.raises(IndexError, match='index value out of bounds'):
+            A.__getitem__((4,))
+
+    def test_setelement(self, spcreator):
+        dtype = np.float64
+        A = spcreator((12,), dtype=dtype)
+        with np.testing.suppress_warnings() as sup:
+            sup.filter(
+                sp.sparse.SparseEfficiencyWarning,
+                "Changing the sparsity structure of a cs[cr]_matrix is expensive",
+            )
+            A[0] = dtype(0)
+            A[1] = dtype(3)
+            A[8] = dtype(9.0)
+            A[-2] = dtype(7)
+            A[5] = 9
+
+            A[-9,] = dtype(8)
+            A[1,] = dtype(5)  # overwrite using 1-tuple index
+
+            for ij in [13, -14, (13,), (14,)]:
+                with pytest.raises(IndexError, match='index value out of bounds'):
+                    A.__setitem__(ij, 123.0)

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -161,11 +161,13 @@ def test_1d_row_and_col():
         res.row = [1, 2, 3]
 
 
-def test_1d_tocsc_tocsr_todia_todok():
+def test_1d_toformats():
     res = coo_array([1, -2, -3])
-    for f in [res.tocsc, res.tocsr, res.todok, res.todia]:
+    for f in [res.tobsr, res.tocsc, res.todia, res.todok, res.tolil]:
         with pytest.raises(ValueError, match='Cannot convert'):
             f()
+    for f in [res.tocoo, res.tocsr]:
+        assert np.array_equal(f().toarray(), res.toarray())
 
 
 @pytest.mark.parametrize('arg', [1, 2, 4, 5, 8])
@@ -233,11 +235,10 @@ def test_1d_add_dense():
 def test_1d_add_sparse():
     den_a = np.array([0, -2, -3, 0])
     den_b = np.array([0, 1, 2, 3])
-    # Currently this routes through CSR format, so 1d sparse addition
-    # isn't supported.
-    with pytest.raises(ValueError,
-                       match='Cannot convert a 1d sparse array'):
-        coo_array(den_a) + coo_array(den_b)
+    dense_sum = den_a + den_b
+    # this routes through CSR format
+    sparse_sum = coo_array(den_a) + coo_array(den_b)
+    assert np.array_equal(dense_sum, sparse_sum.toarray())
 
 
 def test_1d_matmul_vector():

--- a/scipy/sparse/tests/test_indexing1d.py
+++ b/scipy/sparse/tests/test_indexing1d.py
@@ -7,6 +7,9 @@ import scipy as sp
 from .test_arithmetic1d import toarray
 
 
+formats_for_index1d = [sp.sparse.csr_array]
+
+
 @contextlib.contextmanager
 def check_remains_sorted(X):
     """Checks that sorted indices property is retained through an operation
@@ -22,22 +25,23 @@ def check_remains_sorted(X):
                        'Expected sorted indices, found unsorted')
 
 
-class _SlicingAndFancy1D:  # skip name check
+@pytest.mark.parametrize("spcreator", formats_for_index1d)
+class TestSlicingAndFancy1D:
     #####################
     #  Int-like Array Index
     #####################
-    def test_get_array_index(self):
+    def test_get_array_index(self, spcreator):
         D = np.array([4,3,0])
-        A = self.spcreator(D)
+        A = spcreator(D)
 
         assert_array_equal(A[()].toarray(), D[()])
         for ij in [(0,3), (3,)]:
-            with pytest.raises((IndexError, TypeError), match='zq'):
+            with pytest.raises(IndexError, match='out of range'):
                 A.__getitem__(ij)
 
-    def test_set_array_index(self):
+    def test_set_array_index(self, spcreator):
         dtype = np.float64
-        A = self.spcreator((12,), dtype=dtype)
+        A = spcreator((12,), dtype=dtype)
         with np.testing.suppress_warnings() as sup:
             sup.filter(
                 sp.sparse.SparseEfficiencyWarning,
@@ -45,45 +49,47 @@ class _SlicingAndFancy1D:  # skip name check
             )
             A[np.array(6)] = dtype(4.0)  # scalar index
             A[np.array(6)] = dtype(2.0)  # overwrite with scalar index
-            assert_array_equal(A.toarray(), [0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0])
+            assert_array_equal(A.toarray(), [0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0])
 
             for ij in [(13,),(-14,)]:
-                with pytest.raises(IndexError, match='zq'):
+                with pytest.raises(IndexError, match='index .* out of range'):
                     A.__setitem__(ij, 123.0)
 
             for v in [(), (0, 3), [1,2,3], np.array([1,2,3])]:
-                with pytest.raises(ValueError, match='zq'):
+                with pytest.raises(
+                    ValueError, match='Trying to assign a sequence to an item'
+                ):
                     A.__setitem__(0, v)
 
     ####################
     #  1d Slice as index
     ####################
-    def test_dtype_preservation(self):
-        assert_equal(self.spcreator((10,), dtype=np.int16)[1:5].dtype, np.int16)
-        assert_equal(self.spcreator((6,), dtype=np.int32)[0:0:2].dtype, np.int32)
-        assert_equal(self.spcreator((6,), dtype=np.int64)[:].dtype, np.int64)
+    def test_dtype_preservation(self, spcreator):
+        assert_equal(spcreator((10,), dtype=np.int16)[1:5].dtype, np.int16)
+        assert_equal(spcreator((6,), dtype=np.int32)[0:0:2].dtype, np.int32)
+        assert_equal(spcreator((6,), dtype=np.int64)[:].dtype, np.int64)
 
-    def test_get_1d_slice(self):
+    def test_get_1d_slice(self, spcreator):
         B = np.arange(50.)
-        A = self.spcreator(B)
+        A = spcreator(B)
         assert_array_equal(B[:], A[:].toarray())
         assert_array_equal(B[2:5], A[2:5].toarray())
 
         C = np.array([4, 0, 6, 0, 0, 0, 0, 0, 1])
-        D = self.spcreator(C)
+        D = spcreator(C)
         assert_array_equal(C[1:3], D[1:3].toarray())
 
         # Now test slicing when a row contains only zeros
         E = np.array([0, 0, 0, 0, 0])
-        F = self.spcreator(E)
+        F = spcreator(E)
         assert_array_equal(E[1:3], F[1:3].toarray())
         assert_array_equal(E[-2:], F[-2:].toarray())
         assert_array_equal(E[:], F[:].toarray())
         assert_array_equal(E[slice(None)], F[slice(None)].toarray())
 
-    def test_slicing_idx_slice(self):
+    def test_slicing_idx_slice(self, spcreator):
         B = np.arange(50)
-        A = self.spcreator(B)
+        A = spcreator(B)
 
         # [i]
         assert_equal(A[2], B[2])
@@ -118,17 +124,17 @@ class _SlicingAndFancy1D:  # skip name check
                 else:
                     assert_array_equal(x.toarray(), y, repr(a))
 
-    def test_ellipsis_1d_slicing(self):
+    def test_ellipsis_1d_slicing(self, spcreator):
         B = np.arange(50)
-        A = self.spcreator(B)
+        A = spcreator(B)
         assert_array_equal(A[...].toarray(), B[...])
         assert_array_equal(A[...,].toarray(), B[...,])
 
     ##########################
     #  Assignment with Slicing
     ##########################
-    def test_slice_scalar_assign(self):
-        A = self.spcreator((5,))
+    def test_slice_scalar_assign(self, spcreator):
+        A = spcreator((5,))
         B = np.zeros((5,))
         with np.testing.suppress_warnings() as sup:
             sup.filter(
@@ -143,11 +149,11 @@ class _SlicingAndFancy1D:  # skip name check
                 C[3::-1] = 9
         assert_array_equal(A.toarray(), B)
 
-    def test_slice_assign_2(self):
+    def test_slice_assign_2(self, spcreator):
         shape = (10,)
 
         for idx in [slice(3), slice(None, 10, 4), slice(5, -2)]:
-            A = self.spcreator(shape)
+            A = spcreator(shape)
             with np.testing.suppress_warnings() as sup:
                 sup.filter(
                     sp.sparse.SparseEfficiencyWarning,
@@ -159,9 +165,9 @@ class _SlicingAndFancy1D:  # skip name check
             msg = f"idx={idx!r}"
             assert_array_almost_equal(A.toarray(), B, err_msg=msg)
 
-    def test_self_self_assignment(self):
+    def test_self_self_assignment(self, spcreator):
         # Tests whether a row of one lil_matrix can be assigned to another.
-        B = self.spcreator((5,))
+        B = spcreator((5,))
         with np.testing.suppress_warnings() as sup:
             sup.filter(
                 sp.sparse.SparseEfficiencyWarning,
@@ -185,9 +191,8 @@ class _SlicingAndFancy1D:  # skip name check
             B[:-1] = A[1:]
             assert_array_equal(A[1:].toarray(), B[:-1].toarray())
 
-    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
-    def test_slice_assignment(self):
-        B = self.spcreator((4,))
+    def test_slice_assignment(self, spcreator):
+        B = spcreator((4,))
         expected = np.array([10, 0, 14, 0])
         block = [2, 1]
 
@@ -198,14 +203,14 @@ class _SlicingAndFancy1D:  # skip name check
             )
             B[0] = 5
             B[2] = 7
-            B[:] = B+B
+            B[:] = B + B
             assert_array_equal(B.toarray(), expected)
 
-            B[:2] = sp.sparse.csc_array(block)
+            B[:2] = sp.sparse.csr_array(block)
             assert_array_equal(B.toarray()[:2], block)
 
-    def test_set_slice(self):
-        A = self.spcreator((5,))
+    def test_set_slice(self, spcreator):
+        A = spcreator((5,))
         B = np.zeros(5, float)
         s_ = np.s_
         slices = [s_[:2], s_[1:2], s_[3:], s_[3::2],
@@ -229,35 +234,39 @@ class _SlicingAndFancy1D:  # skip name check
 
         # The next commands should raise exceptions
         toobig = list(range(100))
-        with pytest.raises(ValueError, match='zq'):
+        with pytest.raises(ValueError, match='Trying to assign a sequence to an item'):
             A.__setitem__(0, toobig)
-        with pytest.raises(ValueError, match='zq'):
+        with pytest.raises(ValueError, match='could not be broadcast together'):
             A.__setitem__(slice(None), toobig)
 
-    def test_assign_empty(self):
-        A = self.spcreator(np.ones(3))
-        B = self.spcreator((2,))
+    def test_assign_empty(self, spcreator):
+        A = spcreator(np.ones(3))
+        B = spcreator((2,))
         A[:2] = B
         assert_array_equal(A.toarray(), [0, 0, 1])
 
     ####################
     #  1d Fancy Indexing
     ####################
-    def test_dtype_preservation_empty_index(self):
-        A = self.spcreator((2,), dtype=np.int16)
+    def test_dtype_preservation_empty_index(self, spcreator):
+        A = spcreator((2,), dtype=np.int16)
         assert_equal(A[[False, False]].dtype, np.int16)
         assert_equal(A[[]].dtype, np.int16)
 
-    def test_bad_index(self):
-        A = self.spcreator(np.zeros(5))
-        with pytest.raises((IndexError, ValueError, TypeError), match='zq'):
+    def test_bad_index(self, spcreator):
+        A = spcreator(np.zeros(5))
+        with pytest.raises(
+            (IndexError, ValueError, TypeError), match='Index dimension must be 1 or 2'
+        ):
             A.__getitem__("foo")
-        with pytest.raises((IndexError, ValueError, TypeError), match='zq'):
+        with pytest.raises(
+            (IndexError, ValueError, TypeError), match='tuple index out of range'
+        ):
             A.__getitem__((2, "foo"))
 
-    def test_fancy_indexing(self):
+    def test_fancy_indexing(self, spcreator):
         B = np.arange(50)
-        A = self.spcreator(B)
+        A = spcreator(B)
 
         # [i]
         assert_equal(A[[3]].toarray(), B[[3]])
@@ -287,11 +296,11 @@ class _SlicingAndFancy1D:  # skip name check
         assert_equal(A[[-1, -5, 2, 8]][[1, -4]].toarray(),
                      B[[-1, -5, 2, 8]][[1, -4]])
 
-    def test_fancy_indexing_boolean(self):
+    def test_fancy_indexing_boolean(self, spcreator):
         np.random.seed(1234)  # make runs repeatable
 
         B = np.arange(50)
-        A = self.spcreator(B)
+        A = spcreator(B)
 
         I = np.array(np.random.randint(0, 2, size=50), dtype=bool)
 
@@ -304,19 +313,18 @@ class _SlicingAndFancy1D:  # skip name check
         Z3 = np.zeros(51, dtype=bool)
         Z3[0] = True
 
-        with pytest.raises(IndexError, match='zq'):
+        with pytest.raises(IndexError, match='array index shape .* not array shape'):
             A.__getitem__(Z1)
-        with pytest.raises(IndexError, match='zq'):
+        with pytest.raises(IndexError, match='array index shape .* not array shape'):
             A.__getitem__(Z2)
-        with pytest.raises(IndexError, match='zq'):
+        with pytest.raises(IndexError, match='array index shape .* not array shape'):
             A.__getitem__(Z3)
 
-    @pytest.mark.skip(reason="tocsr() not valid for 1d sparse array")
-    def test_fancy_indexing_sparse_boolean(self):
+    def test_fancy_indexing_sparse_boolean(self, spcreator):
         np.random.seed(1234)  # make runs repeatable
 
         B = np.arange(20)
-        A = self.spcreator(B)
+        A = spcreator(B)
 
         X = np.array(np.random.randint(0, 2, size=20), dtype=bool)
         Xsp = sp.sparse.csr_array(X)
@@ -328,21 +336,21 @@ class _SlicingAndFancy1D:  # skip name check
 
         Ysp = sp.sparse.csr_array(Y)
 
-        with pytest.raises(IndexError, match='zq'):
+        with pytest.raises(IndexError, match='array index shape .* not array shape'):
             A.__getitem__(Ysp)
-        with pytest.raises(IndexError, match='zq'):
+        with pytest.raises(IndexError, match='tuple index out of range'):
             A.__getitem__((Xsp, 1))
 
-    def test_fancy_indexing_seq_assign(self):
-        mat = self.spcreator(np.array([1, 0]))
-        with pytest.raises(ValueError, match='zq'):
+    def test_fancy_indexing_seq_assign(self, spcreator):
+        mat = spcreator(np.array([1, 0]))
+        with pytest.raises(ValueError, match='Trying to assign a sequence to an item'):
             mat.__setitem__(0, np.array([1,2]))
 
-    def test_fancy_indexing_empty(self):
+    def test_fancy_indexing_empty(self, spcreator):
         B = np.arange(50)
         B[3:9] = 0
         B[30] = 0
-        A = self.spcreator(B)
+        A = spcreator(B)
 
         K = np.array([False] * 50)
         assert_equal(toarray(A[K]), B[K])
@@ -354,18 +362,20 @@ class _SlicingAndFancy1D:  # skip name check
     ############################
     #  1d Fancy Index Assignment
     ############################
-    def test_bad_index_assign(self):
-        A = self.spcreator(np.zeros(5))
-        with pytest.raises((IndexError, ValueError, TypeError), match='zq'):
+    def test_bad_index_assign(self, spcreator):
+        A = spcreator(np.zeros(5))
+        with pytest.raises(
+            (IndexError, ValueError, TypeError), match='Index dimension must be 1 or 2'
+        ):
             A.__setitem__("foo", 2)
 
-    def test_fancy_indexing_set(self):
+    def test_fancy_indexing_set(self, spcreator):
         M = (5,)
 
         # [1:2]
         for j in [[2, 3, 4], slice(None, 10, 4), np.arange(3),
                      slice(5, -2), slice(2, 5)]:
-            A = self.spcreator(M)
+            A = spcreator(M)
             B = np.zeros(M)
             with np.testing.suppress_warnings() as sup:
                 sup.filter(
@@ -377,9 +387,9 @@ class _SlicingAndFancy1D:  # skip name check
                     A[j] = 1
             assert_array_almost_equal(A.toarray(), B)
 
-    def test_sequence_assignment(self):
-        A = self.spcreator((4,))
-        B = self.spcreator((3,))
+    def test_sequence_assignment(self, spcreator):
+        A = spcreator((4,))
+        B = spcreator((3,))
 
         i0 = [0,1,2]
         i1 = (0,1,2)
@@ -392,31 +402,31 @@ class _SlicingAndFancy1D:  # skip name check
             )
             with check_remains_sorted(A):
                 A[i0] = B[i0]
-                with pytest.raises(IndexError, match='zq'):
+                with pytest.raises(IndexError, match='tuple index out of range'):
                     B.__getitem__(i1)
                 A[i2] = B[i2]
             assert_array_equal(A[:3].toarray(), B.toarray())
             assert A.shape == (4,)
 
             # slice
-            A = self.spcreator((4,))
+            A = spcreator((4,))
             with check_remains_sorted(A):
                 A[1:3] = [10,20]
             assert_array_equal(A.toarray(), [0, 10, 20, 0])
 
             # array
-            A = self.spcreator((4,))
+            A = spcreator((4,))
             B = np.zeros(4)
             with check_remains_sorted(A):
                 for C in [A, B]:
                     C[[0,1,2]] = [4,5,6]
             assert_array_equal(A.toarray(), B)
 
-    def test_fancy_assign_empty(self):
+    def test_fancy_assign_empty(self, spcreator):
         B = np.arange(50)
         B[2] = 0
         B[[3, 6]] = 0
-        A = self.spcreator(B)
+        A = spcreator(B)
 
         K = np.array([False] * 50)
         A[K] = 42
@@ -425,65 +435,3 @@ class _SlicingAndFancy1D:  # skip name check
         K = np.array([], dtype=int)
         A[K] = 42
         assert_equal(A.toarray(), B)
-
-
-class _MinMaxMixin1D:  # skip name check
-    def test_minmax(self):
-        D = np.arange(5)
-        X = self.spcreator(D)
-
-        assert_equal(X.min(), 0)
-        assert_equal(X.max(), 4)
-        assert_equal((-X).min(), -4)
-        assert_equal((-X).max(), 0)
-
-
-    def test_minmax_axis(self):
-        D = np.arange(50)
-        X = self.spcreator(D)
-
-        for axis in [0, -1]:
-            assert_array_equal(
-                toarray(X.max(axis=axis)), D.max(axis=axis, keepdims=True)
-            )
-            assert_array_equal(
-                toarray(X.min(axis=axis)), D.min(axis=axis, keepdims=True)
-            )
-        for axis in [-2, 1]:
-            with pytest.raises(ValueError, match='zq'):
-                X.min(axis=axis)
-            with pytest.raises(ValueError, match='zq'):
-                X.max(axis=axis)
-
-
-    def test_numpy_minmax(self):
-        dat = np.array([0, 1, 2])
-        datsp = self.spcreator(dat)
-        assert_array_equal(np.min(datsp), np.min(dat))
-        assert_array_equal(np.max(datsp), np.max(dat))
-
-
-    def test_argmax(self):
-        D1 = np.array([-1, 5, 2, 3])
-        D2 = np.array([0, 0, -1, -2])
-        D3 = np.array([-1, -2, -3, -4])
-        D4 = np.array([1, 2, 3, 4])
-        D5 = np.array([1, 2, 0, 0])
-
-        for D in [D1, D2, D3, D4, D5]:
-            mat = self.spcreator(D)
-
-            assert_equal(mat.argmax(), np.argmax(D))
-            assert_equal(mat.argmin(), np.argmin(D))
-
-            assert_equal(mat.argmax(axis=0), np.argmax(D, axis=0))
-            assert_equal(mat.argmin(axis=0), np.argmin(D, axis=0))
-
-        D6 = np.empty((0,))
-
-        for axis in [None, 0]:
-            mat = self.spcreator(D6)
-            with pytest.raises(ValueError, match='zq'):
-                mat.argmax(axis=axis)
-            with pytest.raises(ValueError, match='zq'):
-                mat.argmin(axis=axis)


### PR DESCRIPTION
Turn on indexing for 1d csr_arrays!  

This version rewrites `_validate_indices` from scratch using an N-D approach
- adds 1-d sections to getitem and setitem dunders
- rewrites _validate_indices with an N-d approach. 
- Reduce helper functions to one `_compatible_boolean_array` which in-lines its helper functions.
- shorter, more readable, cleaner
- also computes the shape of the output of this indexing.
- passes all tests
- adds 1d test for indexing (and passes those also)

- `__getitem__` and `__setitem__` are still in the 1d/2d paradigm. Changing those will require changing the methods `_get_intXslice` and friends. Probably a rewrite of that is needed for N-D.  When to do that?

This builds on the `csr-1d` branch, but should work with `dok-1d` branch after turning on tests for it. 
And it should work for the 2d-arrays and matrix classes directly off of main (though test_indexing1d.py won't pass obviously).

